### PR TITLE
Relax activerecord dependency

### DIFF
--- a/activerecord-jsonb-associations.gemspec
+++ b/activerecord-jsonb-associations.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.0'
 
-  spec.add_dependency 'activerecord', '~> 5.1.0'
+  spec.add_dependency 'activerecord', ['>= 5.1', '< 6']
 
   spec.add_development_dependency 'rspec', '~> 3.7.0'
 end


### PR DESCRIPTION
Thanks for the gem!

In order to use this with the latest Rails release, I had to relax this dependency.

Please mind #3 before merging.